### PR TITLE
feat: use serde_cyclonedx instead and support CycloneDX 1.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ reqwest = "0.12"
 sectxtlib = "0.3.1"
 sequoia-openpgp = { version = "1", default-features = false }
 serde = "1"
+serde-cyclonedx = "0.9.1"
 serde_json = "1"
 sha2 = "0.10.6"
 spdx-expression = "0.5"

--- a/sbom/Cargo.toml
+++ b/sbom/Cargo.toml
@@ -36,12 +36,13 @@ url = { workspace = true, features = ["serde"] }
 # optional
 cyclonedx-bom = { workspace = true, optional = true }
 spdx-rs = { workspace = true, optional = true }
+serde-cyclonedx = { workspace = true, optional = true }
 
 # internal
 walker-common = { workspace = true, features = ["openpgp"] }
 
 [features]
-default = ["crypto-nettle", "cyclonedx-bom", "spdx-rs"]
+default = ["crypto-nettle", "serde-cyclonedx", "spdx-rs"]
 crypto-cng = ["sequoia-openpgp/crypto-cng"]
 crypto-nettle = ["sequoia-openpgp/crypto-nettle"]
 crypto-openssl = ["sequoia-openpgp/crypto-openssl"]

--- a/sbom/sbom-cli/Cargo.toml
+++ b/sbom/sbom-cli/Cargo.toml
@@ -26,12 +26,11 @@ reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 spdx-expression = { workspace = true }
-spdx-rs = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
 # internal
-sbom-walker = { workspace = true, features = ["cyclonedx-bom", "spdx-rs"] }
+sbom-walker = { workspace = true, features = ["serde-cyclonedx", "spdx-rs"] }
 walker-common = { workspace = true, features = ["openpgp", "cli"] }
 walker-extras = { workspace = true }
 

--- a/sbom/sbom-cli/src/cmd/scan.rs
+++ b/sbom/sbom-cli/src/cmd/scan.rs
@@ -85,7 +85,7 @@ fn process_sbom(sbom: Sbom) {
             );
         }
 
-        Sbom::CycloneDx(_sbom) => {
+        Sbom::SerdeCycloneDx(_sbom) => {
             println!("  CycloneDX");
         }
     }

--- a/sbom/src/model/sbom/serde_cyclonedx.rs
+++ b/sbom/src/model/sbom/serde_cyclonedx.rs
@@ -1,0 +1,133 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+#[derive(Clone, Debug, PartialEq)]
+#[allow(clippy::large_enum_variant)]
+pub enum Sbom {
+    V1_4(serde_cyclonedx::cyclonedx::v_1_4::CycloneDx),
+    V1_5(serde_cyclonedx::cyclonedx::v_1_5::CycloneDx),
+    V1_6(serde_cyclonedx::cyclonedx::v_1_6::CycloneDx),
+}
+
+impl Serialize for Sbom {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::V1_4(sbom) => sbom.serialize(serializer),
+            Self::V1_5(sbom) => sbom.serialize(serializer),
+            Self::V1_6(sbom) => sbom.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Sbom {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // TODO: peek into the version, and select the correct version
+        serde_cyclonedx::cyclonedx::v_1_6::CycloneDx::deserialize(deserializer).map(Self::V1_6)
+    }
+}
+
+macro_rules! attribute {
+    ($name:ident => | $v:ident -> $ret:ty | $access:expr  ) => {
+        pub fn $name(&self) -> $ret {
+            match self {
+                Self::V1_4($v) => $access,
+                Self::V1_5($v) => $access,
+                Self::V1_6($v) => $access,
+            }
+        }
+    };
+}
+
+macro_rules! from {
+    ( $($lt:lifetime,)? $src:ident, $name:ty) => {
+        impl <$($lt,)? > From<$(& $lt)? serde_cyclonedx::cyclonedx::v_1_4::$src> for $name {
+            fn from(value: $(& $lt)? serde_cyclonedx::cyclonedx::v_1_4::$src) -> Self {
+                Self::V1_4(value)
+            }
+        }
+
+        impl <$($lt,)? > From<$(& $lt)? serde_cyclonedx::cyclonedx::v_1_5::$src> for $name {
+            fn from(value: $(& $lt)? serde_cyclonedx::cyclonedx::v_1_5::$src) -> Self {
+                Self::V1_5(value)
+            }
+        }
+
+        impl <$($lt,)? > From<$(& $lt)? serde_cyclonedx::cyclonedx::v_1_6::$src> for $name {
+            fn from(value: $(& $lt)? serde_cyclonedx::cyclonedx::v_1_6::$src) -> Self {
+                Self::V1_6(value)
+            }
+        }
+    };
+}
+
+impl Sbom {
+    attribute!(components => |sbom -> Option<Vec<Component>> | sbom
+                .components
+                .as_ref()
+                .map(|c| c.iter().map(Into::into).collect()));
+
+    attribute!(dependencies => |sbom -> Option<Vec<Dependency>> | sbom
+                .dependencies
+                .as_ref()
+                .map(|c| c.iter().map(Into::into).collect()));
+}
+
+from!(CycloneDx, Sbom);
+
+// component
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Component<'a> {
+    V1_4(&'a serde_cyclonedx::cyclonedx::v_1_4::Component),
+    V1_5(&'a serde_cyclonedx::cyclonedx::v_1_5::Component),
+    V1_6(&'a serde_cyclonedx::cyclonedx::v_1_6::Component),
+}
+
+from!('a, Component,  Component<'a>);
+
+impl<'a> Component<'a> {
+    attribute!(bom_ref => |c -> Option<&'a str> | c.bom_ref.as_deref());
+}
+
+// dependency
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Dependency<'a> {
+    V1_4(&'a serde_cyclonedx::cyclonedx::v_1_4::Dependency),
+    V1_5(&'a serde_cyclonedx::cyclonedx::v_1_5::Dependency),
+    V1_6(&'a serde_cyclonedx::cyclonedx::v_1_6::Dependency),
+}
+
+from!('a, Dependency,  Dependency<'a>);
+
+impl Dependency<'_> {
+    pub fn r#ref(&self) -> &str {
+        match self {
+            Self::V1_4(dep) => &dep.ref_,
+            Self::V1_5(dep) => dep.ref_.as_str().unwrap_or_default(),
+            Self::V1_6(dep) => &dep.ref_,
+        }
+    }
+
+    pub fn dependencies(&self) -> Option<Vec<&str>> {
+        match self {
+            Self::V1_4(dep) => dep
+                .depends_on
+                .as_ref()
+                .map(|deps| deps.iter().map(|s| s.as_str()).collect()),
+            Self::V1_5(dep) => dep
+                .depends_on
+                .as_ref()
+                .map(|deps| deps.iter().flat_map(|s| s.as_str()).collect()),
+            Self::V1_6(dep) => dep
+                .depends_on
+                .as_ref()
+                .map(|deps| deps.iter().map(|s| s.as_str()).collect()),
+        }
+    }
+}

--- a/sbom/src/report/check/mod.rs
+++ b/sbom/src/report/check/mod.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "cyclonedx-bom")]
 pub mod cyclonedx;
+#[cfg(feature = "serde-cyclonedx")]
+pub mod serde_cyclonedx;
 #[cfg(feature = "spdx-rs")]
 pub mod spdx;
 
@@ -15,7 +17,13 @@ pub fn all(#[allow(unused)] report: &dyn ReportSink, #[allow(unused)] sbom: &Sbo
     }
     #[cfg(feature = "cyclonedx-bom")]
     #[allow(irrefutable_let_patterns)]
+    #[allow(deprecated)]
     if let Sbom::CycloneDx(sbom) = sbom {
         cyclonedx::all(report, sbom);
+    }
+    #[cfg(feature = "serde-cyclonedx")]
+    #[allow(irrefutable_let_patterns)]
+    if let Sbom::SerdeCycloneDx(sbom) = sbom {
+        serde_cyclonedx::all(report, sbom);
     }
 }

--- a/sbom/tests/sbom.rs
+++ b/sbom/tests/sbom.rs
@@ -1,7 +1,6 @@
-use sbom_walker::Sbom;
-
+#[cfg(feature = "cyclonedx-bom")]
 #[test]
 fn test_cyclonedx_v13_json() {
-    let _ =
-        Sbom::try_cyclonedx_json(include_bytes!("data/cyclonedx.v1_3.json")).expect("must parse");
+    let _ = sbom_walker::Sbom::try_cyclonedx_json(include_bytes!("data/cyclonedx.v1_3.json"))
+        .expect("must parse");
 }


### PR DESCRIPTION
BREAKING-CHANGE: This deprecates the use of cyclonedx-bom, dropping direct support for CDX 1.3. Also switching Rust types.