### PR TITLE
fix: properly implement ROLIE source discovery

### DIFF
--- a/csaf/src/discover.rs
+++ b/csaf/src/discover.rs
@@ -59,6 +59,10 @@ pub struct DiscoveredAdvisory {
     pub context: Arc<DistributionContext>,
     /// The URL of the advisory
     pub url: Url,
+    /// The URL of the digest
+    pub digest: Option<Url>,
+    /// The URL of the signature
+    pub signature: Option<Url>,
     /// The "last changed" date from the change information
     pub modified: SystemTime,
 }

--- a/csaf/src/rolie/mod.rs
+++ b/csaf/src/rolie/mod.rs
@@ -30,8 +30,15 @@ impl From<Error> for HttpSourceError {
 
 #[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize)]
 pub struct SourceFile {
-    /// The relative file name
+    /// The relative or absolute file name
     pub file: String,
+
+    /// The relative or absolute file name to the hash
+    pub digest: Option<String>,
+
+    /// The relative or absolute file name to the signature
+    pub signature: Option<String>,
+
     /// The timestamp of the last change
     #[serde(with = "time::serde::iso8601")]
     pub timestamp: OffsetDateTime,
@@ -47,17 +54,83 @@ impl RolieSource {
     pub async fn retrieve(fetcher: &Fetcher, base_url: Url) -> Result<Self, Error> {
         let mut files = vec![];
         let Json(result) = fetcher.fetch::<Json<RolieFeed>>(base_url).await?;
-        for url in result.feed.entry {
-            for link in url.link {
-                files.push(SourceFile {
-                    file: link.href,
-                    timestamp: url.updated,
-                })
-            }
+        for entry in result.feed.entry {
+            files.push(find_file(entry));
         }
 
         log::debug!("found {:?} files", files.len());
 
         Ok(Self { files })
+    }
+}
+
+fn find_file(entry: Entry) -> SourceFile {
+    let mut file = None;
+    let mut signature = None;
+    let mut digest = None;
+
+    for link in entry.link {
+        match &*link.rel {
+            "self" => file = Some(link.href),
+            "signature" => signature = Some(link.href),
+            "hash" => digest = Some(link.href),
+            _ => continue,
+        }
+    }
+
+    SourceFile {
+        file: file.unwrap_or(entry.content.src),
+        timestamp: entry.updated,
+        signature,
+        digest,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use time::macros::datetime;
+
+    #[test]
+    fn find_by_link() {
+        let result = find_file(Entry {
+            link: vec![
+                Link {
+                    rel: "self".to_string(),
+                    href: "https://example.com/foo/bar/1.json".to_string(),
+                },
+                Link {
+                    rel: "hash".to_string(),
+                    href: "https://example.com/foo/bar/1.json.sha512".to_string(),
+                },
+                Link {
+                    rel: "signature".to_string(),
+                    href: "https://example.com/foo/bar/1.json.asc".to_string(),
+                },
+            ],
+            format: Format {
+                schema: "https://docs.oasis-open.org/csaf/csaf/v2.0/csaf_json_schema.json"
+                    .to_string(),
+                version: "2.0".to_string(),
+            },
+            id: "1".to_string(),
+            published: datetime!(2025-01-01 00:00:00 UTC ),
+            title: "Example entry".to_string(),
+            updated: datetime!(2025-01-02 00:00:00 UTC ),
+            content: Content {
+                src: "https://example.com/foo/bar/1.json".to_string(),
+                content_type: "application/json".to_string(),
+            },
+        });
+
+        assert_eq!(
+            result,
+            SourceFile {
+                file: "https://example.com/foo/bar/1.json".to_string(),
+                digest: Some("https://example.com/foo/bar/1.json.sha512".to_string()),
+                signature: Some("https://example.com/foo/bar/1.json.asc".to_string()),
+                timestamp: datetime!(2025-01-02 00:00:00 UTC ),
+            }
+        );
     }
 }

--- a/csaf/src/source/file.rs
+++ b/csaf/src/source/file.rs
@@ -224,6 +224,8 @@ impl Source for FileSource {
             result.push(DiscoveredAdvisory {
                 url,
                 modified,
+                digest: None,
+                signature: None,
                 context: context.clone(),
             })
         }

--- a/csaf/src/validation/mod.rs
+++ b/csaf/src/validation/mod.rs
@@ -67,6 +67,7 @@ impl AsRetrieved for ValidatedAdvisory {
 }
 
 #[derive(Debug, thiserror::Error)]
+#[allow(clippy::large_enum_variant)]
 pub enum ValidationError<S: Source> {
     Retrieval(RetrievalError<DiscoveredAdvisory, S>),
     DigestMismatch {

--- a/csaf/src/visitors/filter.rs
+++ b/csaf/src/visitors/filter.rs
@@ -201,6 +201,8 @@ mod test {
                 DiscoveredAdvisory {
                     context,
                     url,
+                    digest: None,
+                    signature: None,
                     modified,
                 },
             )

--- a/csaf/src/visitors/store.rs
+++ b/csaf/src/visitors/store.rs
@@ -59,6 +59,7 @@ impl StoreVisitor {
 }
 
 #[derive(Debug, thiserror::Error)]
+#[allow(clippy::large_enum_variant)]
 pub enum StoreRetrievedError<S: Source> {
     #[error(transparent)]
     Store(#[from] StoreError),


### PR DESCRIPTION
ROLIE feeds have a content field and a list of links. Those links have a relationship information. So not all links are actually documents. This was ignored before.