### PR TITLE
drop liblzma for lzma-rust2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,33 +34,33 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-22.04-arm
             install: sudo apt install clang llvm pkg-config nettle-dev
-            args: --features crypto-openssl,walker-common/liblzma,csaf --no-default-features
+            args: --features crypto-openssl,walker-common/lzma,csaf --no-default-features
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-22.04
             install: sudo apt install clang llvm pkg-config nettle-dev
-            args: --features crypto-openssl,walker-common/liblzma,csaf --no-default-features
+            args: --features crypto-openssl,walker-common/lzma,csaf --no-default-features
 
           - target: aarch64-unknown-linux-musl
             os: ubuntu-22.04-arm
             install: sudo apt install clang llvm pkg-config libssl-dev nettle-dev musl-tools
-            args: --features vendored,crypto-openssl,walker-common/liblzma,csaf --no-default-features
+            args: --features vendored,crypto-openssl,walker-common/lzma,csaf --no-default-features
           - target: x86_64-unknown-linux-musl
             os: ubuntu-22.04
             install: sudo apt install clang llvm pkg-config libssl-dev nettle-dev musl-tools
-            args: --features vendored,crypto-openssl,walker-common/liblzma,csaf --no-default-features
+            args: --features vendored,crypto-openssl,walker-common/lzma,csaf --no-default-features
 
           - target: x86_64-apple-darwin
             os: macos-15-intel
-            args: --features vendored,crypto-openssl,walker-common/liblzma,csaf --no-default-features
+            args: --features vendored,crypto-openssl,walker-common/lzma,csaf --no-default-features
           - target: aarch64-apple-darwin
             os: macos-15
-            args: --features vendored,crypto-openssl,walker-common/liblzma,csaf --no-default-features
+            args: --features vendored,crypto-openssl,walker-common/lzma,csaf --no-default-features
 
           - target: x86_64-pc-windows-msvc
             os: windows-2022
             exe: ".exe"
             #args: --features crypto-openssl,csaf --no-default-features
-            args: --features crypto-cng,walker-common/liblzma,csaf --no-default-features
+            args: --features crypto-cng,walker-common/lzma,csaf --no-default-features
             install: |
               echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
               vcpkg install openssl:x64-windows-static-md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.91.0"
-version = "0.15.1"
+version = "0.16.0"
 
 [workspace.dependencies]
 anyhow = "1"
@@ -47,7 +47,7 @@ humantime = "2"
 indicatif = "0.18.0"
 indicatif-log-bridge = "0.2.1"
 jsonpath-rust = "1"
-liblzma = ">=0.3, <0.5"
+lzma-rust2 = "0.16.2"
 log = "0.4.17"
 openid = "0.22.0"
 openssl = { version = "0.10" }
@@ -75,10 +75,10 @@ walkdir = "2.4"
 
 # internal dependencies
 
-csaf-walker = { version = "0.15.0", path = "csaf", default-features = false }
-sbom-walker = { version = "0.15.0", path = "sbom", default-features = false }
-walker-common = { version = "0.15.0", path = "common" }
-walker-extras = { version = "0.15.0", path = "extras" }
+csaf-walker = { version = "0.16.0", path = "csaf", default-features = false }
+sbom-walker = { version = "0.16.0", path = "sbom", default-features = false }
+walker-common = { version = "0.16.0", path = "common" }
+walker-extras = { version = "0.16.0", path = "extras" }
 
 [workspace.metadata.release]
 tag = false

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -55,21 +55,19 @@ bzip2-rs = { workspace = true, optional = true, features = ["rustc_1_51"] }
 clap = { workspace = true, features = ["derive", "env"], optional = true }
 env_logger = { workspace = true, optional = true }
 flate2 = { workspace = true, optional = true }
-liblzma = { workspace = true, optional = true }
+lzma-rust2 = { workspace = true, optional = true }
 sequoia-openpgp = { workspace = true, optional = true }
 
 [features]
 default = ["bzip2"]
 openpgp = ["sequoia-openpgp"]
 s3 = ["dep:aws-config", "dep:aws-sdk-s3"]
-
-# deprecated
-cli = ["clap", "env_logger"]
+lzma = ["dep:lzma-rust2"]
 
 _crypto-nettle = ["sequoia-openpgp/crypto-nettle"]
 _test = [
     "bzip2",
-    "liblzma",
+    "lzma",
     "flate2"
 ]
 
@@ -81,7 +79,6 @@ always_include_features = [
     "sequoia-openpgp/crypto-nettle",
 ]
 denylist = [
-    "cli",
     "_crypto-nettle",
     "_test",
     "_semver",

--- a/common/src/compression/detecting.rs
+++ b/common/src/compression/detecting.rs
@@ -15,7 +15,7 @@ pub enum Compression {
     None,
     #[cfg(any(feature = "bzip2", feature = "bzip2-rs"))]
     Bzip2,
-    #[cfg(feature = "liblzma")]
+    #[cfg(feature = "lzma")]
     Xz,
     #[cfg(feature = "flate2")]
     Gzip,
@@ -79,23 +79,11 @@ impl Compression {
     ) -> Result<Option<Bytes>, std::io::Error> {
         match self {
             #[cfg(any(feature = "bzip2", feature = "bzip2-rs"))]
-            Compression::Bzip2 =>
-            {
-                #[allow(deprecated)]
-                super::decompress_bzip2_with(data, opts).map(Some)
-            }
-            #[cfg(feature = "liblzma")]
-            Compression::Xz =>
-            {
-                #[allow(deprecated)]
-                super::decompress_xz_with(data, opts).map(Some)
-            }
+            Compression::Bzip2 => super::decompress_bzip2_with(data, opts).map(Some),
+            #[cfg(feature = "lzma")]
+            Compression::Xz => super::decompress_xz_with(data, opts).map(Some),
             #[cfg(feature = "flate2")]
-            Compression::Gzip =>
-            {
-                #[allow(deprecated)]
-                super::decompress_gzip_with(data, opts).map(Some)
-            }
+            Compression::Gzip => super::decompress_gzip_with(data, opts).map(Some),
             Compression::None => Ok(None),
         }
     }
@@ -139,7 +127,7 @@ impl<'a> Detector<'a> {
             if file_name.ends_with(".bz2") {
                 return Ok(Compression::Bzip2);
             }
-            #[cfg(feature = "liblzma")]
+            #[cfg(feature = "lzma")]
             if file_name.ends_with(".xz") {
                 return Ok(Compression::Xz);
             }
@@ -162,7 +150,7 @@ impl<'a> Detector<'a> {
             if data.starts_with(b"BZh") {
                 return Ok(Compression::Bzip2);
             }
-            #[cfg(feature = "liblzma")]
+            #[cfg(feature = "lzma")]
             if data.starts_with(&[0xFD, 0x37, 0x7A, 0x58, 0x5A, 0x00]) {
                 return Ok(Compression::Xz);
             }
@@ -206,7 +194,7 @@ mod test {
         assert_eq!(detect("foo.bar.bz2"), Compression::Bzip2);
     }
 
-    #[cfg(feature = "liblzma")]
+    #[cfg(feature = "lzma")]
     #[test]
     fn by_name_xz() {
         assert_eq!(detect("foo.bar.xz"), Compression::Xz);

--- a/common/src/compression/mod.rs
+++ b/common/src/compression/mod.rs
@@ -33,28 +33,20 @@ pub fn decompress(data: Bytes, name: &str) -> Result<Bytes, anyhow::Error> {
 
 /// Decompress bz2 using `bzip2-rs` (pure Rust version)
 #[cfg(all(feature = "bzip2-rs", not(feature = "bzip2")))]
-#[deprecated(since = "0.9.3", note = "Use Compression::decompress instead")]
-pub fn decompress_bzip2(data: &[u8]) -> Result<Bytes, std::io::Error> {
+#[allow(unused)]
+fn decompress_bzip2(data: &[u8]) -> Result<Bytes, std::io::Error> {
     #[allow(deprecated)]
     decompress_bzip2_with(data, &DecompressionOptions::default())
 }
 
 /// Decompress bz2 using `bzip2-rs` (pure Rust version)
 #[cfg(all(feature = "bzip2-rs", not(feature = "bzip2")))]
-#[deprecated(since = "0.9.3", note = "Use Compression::decompress instead")]
-pub fn decompress_bzip2_with(
+fn decompress_bzip2_with(
     data: &[u8],
     opts: &DecompressionOptions,
 ) -> Result<Bytes, std::io::Error> {
     let decoder = bzip2_rs::DecoderReader::new(data);
     decompress_limit(decoder, opts.limit)
-}
-
-/// Decompress bz2 using `bzip2` (based on `libbz2`).
-#[cfg(feature = "bzip2")]
-#[deprecated(since = "0.9.3", note = "Use Compression::decompress instead")]
-pub fn decompress_bzip2(data: &[u8]) -> Result<Bytes, std::io::Error> {
-    decompress_bzip2_with(data, &DecompressionOptions::default())
 }
 
 /// Decompress bz2 using `bzip2` (based on `libbz2`).
@@ -67,17 +59,10 @@ fn decompress_bzip2_with(
     decompress_limit(decoder, opts.limit)
 }
 
-/// Decompress xz using `liblzma`.
-#[cfg(feature = "liblzma")]
-#[deprecated(since = "0.9.3", note = "Use Compression::decompress instead")]
-pub fn decompress_xz(data: &[u8]) -> Result<Bytes, std::io::Error> {
-    decompress_xz_with(data, &Default::default())
-}
-
-/// Decompress xz using `liblzma`.
-#[cfg(feature = "liblzma")]
+/// Decompress xz using `lzma-rust2`.
+#[cfg(feature = "lzma")]
 fn decompress_xz_with(data: &[u8], opts: &DecompressionOptions) -> Result<Bytes, std::io::Error> {
-    let decoder = liblzma::read::XzDecoder::new(data);
+    let decoder = lzma_rust2::XzReader::new(data, false);
     decompress_limit(decoder, opts.limit)
 }
 

--- a/csaf/Cargo.toml
+++ b/csaf/Cargo.toml
@@ -53,7 +53,7 @@ hyper = { version = "1", features = ["server", "http1"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net"] }
-walker-common = { workspace = true, features = ["openpgp", "liblzma"] }
+walker-common = { workspace = true, features = ["openpgp", "lzma"] }
 
 [features]
 default = ["crypto-nettle", "csaf"]

--- a/csaf/csaf-cli/Cargo.toml
+++ b/csaf/csaf-cli/Cargo.toml
@@ -64,4 +64,5 @@ denylist = [
     "crypto-openssl",
     "crypto-botan",
     "crypto-rust",
+    "vendored",
 ]

--- a/extras/Cargo.toml
+++ b/extras/Cargo.toml
@@ -44,7 +44,7 @@ _crypto-nettle = [
 ]
 _test = [
     "walker-common/bzip2",
-    "walker-common/liblzma",
+    "walker-common/lzma",
     "walker-common/flate2"
 ]
 

--- a/sbom/sbom-cli/Cargo.toml
+++ b/sbom/sbom-cli/Cargo.toml
@@ -56,6 +56,7 @@ denylist = [
     "crypto-openssl",
     "crypto-botan",
     "crypto-rust",
+    "vendored",
 ]
 
 [[bin]]


### PR DESCRIPTION
## Summary by Sourcery

Switch xz compression support from liblzma to lzma-rust2 and refresh CI release tooling and configuration.

New Features:
- Provide xz decompression via the lzma-rust2 crate instead of liblzma.

Enhancements:
- Update compression feature flags and workspace dependencies to use lzma-rust2 across crates.
- Bump workspace version to 0.16.0.

CI:
- Update release workflow to newer GitHub Actions versions, artifact actions, and macOS runners, and simplify the macOS build step.