### PR TITLE
fix: restore hard errors on 404 and optional data

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,16 +28,16 @@ jobs:
       matrix_include: |
         [
           {
-            "os": "ubuntu-22.04",
+            "os": "ubuntu-24.04",
             "install": "sudo apt install clang llvm pkg-config nettle-dev"
           },
           {
-            "os": "windows-2022",
+           "os": "windows-2025",
             "args": "--features crypto-cng --no-default-features",
             "skip_all_features": true
           },
           {
-            "os": "macos-14",
+            "os": "macos-15",
             "skip_all_features": true
           }
         ]

--- a/common/src/http.rs
+++ b/common/src/http.rs
@@ -55,8 +55,8 @@ pub fn calculate_retry_after_from_response_header(
     None
 }
 
-pub fn get_client_error(response: &Response) -> Option<StatusCode> {
-    let status = response.status();
+/// If the status is [`StatusCode::is_client_error`] then return `Option::Some()` with the code.
+pub fn get_client_error(status: StatusCode) -> Option<StatusCode> {
     if status.is_client_error() {
         Some(status)
     } else {


### PR DESCRIPTION
## Summary by Sourcery

Handle HTTP 404 responses as non-fatal for optional fetch results while still surfacing other client errors consistently.

Bug Fixes:
- Restore proper client error propagation by deriving client error status codes from processing errors instead of only from raw responses.
- Treat 404 responses as successful fetches returning None when fetching optional data types instead of failing with a client error.

Enhancements:
- Adjust the HTTP helper to classify client errors based on a StatusCode input rather than an entire response object for more flexible error handling.

Tests:
- Expand fetcher tests to cover optional data semantics on 404 and verify no retries occur when a 404 is returned.