### PR TITLE
feat: handle ignored errors in report

### DIFF
--- a/csaf/csaf-cli/Cargo.toml
+++ b/csaf/csaf-cli/Cargo.toml
@@ -66,3 +66,6 @@ denylist = [
     "crypto-rust",
     "vendored",
 ]
+
+[dev-dependencies]
+rstest = { workspace = true }

--- a/csaf/csaf-cli/src/cmd/report/mod.rs
+++ b/csaf/csaf-cli/src/cmd/report/mod.rs
@@ -254,3 +254,106 @@ fn get_client_error_status(
     };
     Some(*status)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use csaf_walker::discover::DistributionContext;
+    use csaf_walker::{discover::DiscoveredAdvisory, retrieve::RetrievedAdvisory};
+    use std::sync::Arc;
+    use walker_common::retrieve::RetrievalMetadata;
+
+    fn test_discovered() -> DiscoveredAdvisory {
+        DiscoveredAdvisory {
+            context: Arc::new(DistributionContext::Directory(
+                Url::parse("https://example.com/advisories/").unwrap(),
+            )),
+            url: Url::parse("https://example.com/advisories/test.json").unwrap(),
+            digest: None,
+            signature: None,
+            modified: std::time::SystemTime::now(),
+        }
+    }
+
+    fn test_retrieved() -> RetrievedAdvisory {
+        RetrievedAdvisory {
+            discovered: test_discovered(),
+            data: bytes::Bytes::from_static(b"{}"),
+            signature: None,
+            sha256: None,
+            sha512: None,
+            metadata: RetrievalMetadata {
+                last_modification: None,
+                etag: None,
+            },
+        }
+    }
+
+    fn make_client_error(
+        status: StatusCode,
+    ) -> VerificationError<ValidationError<DispatchSource>, ValidatedAdvisory> {
+        VerificationError::Upstream(ValidationError::Retrieval(RetrievalError::Source {
+            discovered: test_discovered(),
+            err: DispatchSourceError::Http(HttpSourceError::Fetcher(
+                fetcher::Error::ClientError(status),
+            )),
+        }))
+    }
+
+    #[test]
+    fn extract_404_client_error() {
+        let err = make_client_error(StatusCode::NOT_FOUND);
+        assert_eq!(get_client_error_status(&err), Some(StatusCode::NOT_FOUND));
+    }
+
+    #[test]
+    fn extract_403_client_error() {
+        let err = make_client_error(StatusCode::FORBIDDEN);
+        assert_eq!(get_client_error_status(&err), Some(StatusCode::FORBIDDEN));
+    }
+
+    #[test]
+    fn returns_none_for_parsing_error() {
+        let err: VerificationError<ValidationError<DispatchSource>, ValidatedAdvisory> =
+            VerificationError::Parsing {
+                advisory: ValidatedAdvisory {
+                    retrieved: test_retrieved(),
+                },
+                error: serde_json::from_str::<String>("invalid").unwrap_err(),
+            };
+        assert_eq!(get_client_error_status(&err), None);
+    }
+
+    #[test]
+    fn returns_none_for_digest_mismatch() {
+        let err: VerificationError<ValidationError<DispatchSource>, ValidatedAdvisory> =
+            VerificationError::Upstream(ValidationError::DigestMismatch {
+                expected: "abc".to_string(),
+                actual: "def".to_string(),
+                retrieved: test_retrieved(),
+            });
+        assert_eq!(get_client_error_status(&err), None);
+    }
+
+    #[test]
+    fn returns_none_for_file_source_error() {
+        let err: VerificationError<ValidationError<DispatchSource>, ValidatedAdvisory> =
+            VerificationError::Upstream(ValidationError::Retrieval(RetrievalError::Source {
+                discovered: test_discovered(),
+                err: DispatchSourceError::File(anyhow::anyhow!("file not found")),
+            }));
+        assert_eq!(get_client_error_status(&err), None);
+    }
+
+    #[test]
+    fn returns_none_for_rate_limited_error() {
+        let err: VerificationError<ValidationError<DispatchSource>, ValidatedAdvisory> =
+            VerificationError::Upstream(ValidationError::Retrieval(RetrievalError::Source {
+                discovered: test_discovered(),
+                err: DispatchSourceError::Http(HttpSourceError::Fetcher(
+                    fetcher::Error::RateLimited(std::time::Duration::from_secs(60)),
+                )),
+            }));
+        assert_eq!(get_client_error_status(&err), None);
+    }
+}

--- a/csaf/csaf-cli/src/cmd/report/mod.rs
+++ b/csaf/csaf-cli/src/cmd/report/mod.rs
@@ -4,9 +4,12 @@ use crate::{
 };
 use csaf_walker::{
     discover::AsDiscovered,
-    report::{DocumentKey, Duplicates, ReportRenderOption, ReportResult, render_to_html},
+    report::{
+        DocumentKey, Duplicates, ReportRenderOption, ReportResult, get_client_error_status,
+        render_to_html,
+    },
     retrieve::RetrievingVisitor,
-    source::{DispatchSource, DispatchSourceError, HttpSourceError},
+    source::DispatchSource,
     validation::{ValidatedAdvisory, ValidationError, ValidationVisitor},
     verification::{
         VerificationError, VerifiedAdvisory, VerifyingVisitor,
@@ -29,7 +32,6 @@ use walker_common::{
         CommandDefaults, client::ClientArguments, parser::parse_allow_client_errors,
         runner::RunnerArguments, validation::ValidationArguments,
     },
-    fetcher,
     progress::Progress,
     report::{self, Statistics},
     retrieve::RetrievalError,
@@ -137,11 +139,11 @@ impl Report {
                                 },
                             };
 
-                            if let Some(status) = get_client_error_status(&err) {
-                                if allowed_client_errors.contains(&status) {
-                                    ignored_errors.lock().await.insert(name, status);
-                                    return Ok::<_, anyhow::Error>(());
-                                }
+                            if let Some(status) = get_client_error_status(&err)
+                                && allowed_client_errors.contains(&status)
+                            {
+                                ignored_errors.lock().await.insert(name, status);
+                                return Ok::<_, anyhow::Error>(());
                             }
 
                             errors.lock().await.insert(name, err.to_string());
@@ -236,32 +238,14 @@ impl Report {
     }
 }
 
-/// Extract the HTTP client error status code from a verification error, if present.
-fn get_client_error_status(
-    err: &VerificationError<ValidationError<DispatchSource>, ValidatedAdvisory>,
-) -> Option<StatusCode> {
-    let VerificationError::Upstream(validation_err) = err else {
-        return None;
-    };
-    let ValidationError::Retrieval(retrieval_err) = validation_err else {
-        return None;
-    };
-    let RetrievalError::Source { err, .. } = retrieval_err;
-    let DispatchSourceError::Http(HttpSourceError::Fetcher(fetcher::Error::ClientError(status))) =
-        err
-    else {
-        return None;
-    };
-    Some(*status)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use csaf_walker::discover::DistributionContext;
+    use csaf_walker::source::{DispatchSourceError, HttpSourceError};
     use csaf_walker::{discover::DiscoveredAdvisory, retrieve::RetrievedAdvisory};
     use std::sync::Arc;
-    use walker_common::retrieve::RetrievalMetadata;
+    use walker_common::{fetcher, retrieve::RetrievalMetadata};
 
     fn test_discovered() -> DiscoveredAdvisory {
         DiscoveredAdvisory {
@@ -294,9 +278,9 @@ mod tests {
     ) -> VerificationError<ValidationError<DispatchSource>, ValidatedAdvisory> {
         VerificationError::Upstream(ValidationError::Retrieval(RetrievalError::Source {
             discovered: test_discovered(),
-            err: DispatchSourceError::Http(HttpSourceError::Fetcher(
-                fetcher::Error::ClientError(status),
-            )),
+            err: DispatchSourceError::Http(HttpSourceError::Fetcher(fetcher::Error::ClientError(
+                status,
+            ))),
         }))
     }
 

--- a/csaf/csaf-cli/src/cmd/report/mod.rs
+++ b/csaf/csaf-cli/src/cmd/report/mod.rs
@@ -244,6 +244,7 @@ mod tests {
     use csaf_walker::discover::DistributionContext;
     use csaf_walker::source::{DispatchSourceError, HttpSourceError};
     use csaf_walker::{discover::DiscoveredAdvisory, retrieve::RetrievedAdvisory};
+    use rstest::rstest;
     use std::sync::Arc;
     use walker_common::{fetcher, retrieve::RetrievalMetadata};
 
@@ -284,60 +285,58 @@ mod tests {
         }))
     }
 
-    #[test]
-    fn extract_404_client_error() {
-        let err = make_client_error(StatusCode::NOT_FOUND);
-        assert_eq!(get_client_error_status(&err), Some(StatusCode::NOT_FOUND));
+    #[rstest]
+    #[case::not_found(StatusCode::NOT_FOUND)]
+    #[case::forbidden(StatusCode::FORBIDDEN)]
+    fn extract_client_error(#[case] status: StatusCode) {
+        let err = make_client_error(status);
+        assert_eq!(get_client_error_status(&err), Some(status));
     }
 
-    #[test]
-    fn extract_403_client_error() {
-        let err = make_client_error(StatusCode::FORBIDDEN);
-        assert_eq!(get_client_error_status(&err), Some(StatusCode::FORBIDDEN));
-    }
-
-    #[test]
-    fn returns_none_for_parsing_error() {
-        let err: VerificationError<ValidationError<DispatchSource>, ValidatedAdvisory> =
-            VerificationError::Parsing {
-                advisory: ValidatedAdvisory {
-                    retrieved: test_retrieved(),
-                },
-                error: serde_json::from_str::<String>("invalid").unwrap_err(),
-            };
-        assert_eq!(get_client_error_status(&err), None);
-    }
-
-    #[test]
-    fn returns_none_for_digest_mismatch() {
-        let err: VerificationError<ValidationError<DispatchSource>, ValidatedAdvisory> =
-            VerificationError::Upstream(ValidationError::DigestMismatch {
-                expected: "abc".to_string(),
-                actual: "def".to_string(),
+    fn parsing_error() -> VerificationError<ValidationError<DispatchSource>, ValidatedAdvisory> {
+        VerificationError::Parsing {
+            advisory: ValidatedAdvisory {
                 retrieved: test_retrieved(),
-            });
-        assert_eq!(get_client_error_status(&err), None);
+            },
+            error: serde_json::from_str::<String>("invalid").unwrap_err(),
+        }
     }
 
-    #[test]
-    fn returns_none_for_file_source_error() {
-        let err: VerificationError<ValidationError<DispatchSource>, ValidatedAdvisory> =
-            VerificationError::Upstream(ValidationError::Retrieval(RetrievalError::Source {
-                discovered: test_discovered(),
-                err: DispatchSourceError::File(anyhow::anyhow!("file not found")),
-            }));
-        assert_eq!(get_client_error_status(&err), None);
+    fn digest_mismatch_error()
+    -> VerificationError<ValidationError<DispatchSource>, ValidatedAdvisory> {
+        VerificationError::Upstream(ValidationError::DigestMismatch {
+            expected: "abc".to_string(),
+            actual: "def".to_string(),
+            retrieved: test_retrieved(),
+        })
     }
 
-    #[test]
-    fn returns_none_for_rate_limited_error() {
-        let err: VerificationError<ValidationError<DispatchSource>, ValidatedAdvisory> =
-            VerificationError::Upstream(ValidationError::Retrieval(RetrievalError::Source {
-                discovered: test_discovered(),
-                err: DispatchSourceError::Http(HttpSourceError::Fetcher(
-                    fetcher::Error::RateLimited(std::time::Duration::from_secs(60)),
-                )),
-            }));
+    fn file_source_error() -> VerificationError<ValidationError<DispatchSource>, ValidatedAdvisory>
+    {
+        VerificationError::Upstream(ValidationError::Retrieval(RetrievalError::Source {
+            discovered: test_discovered(),
+            err: DispatchSourceError::File(anyhow::anyhow!("file not found")),
+        }))
+    }
+
+    fn rate_limited_error() -> VerificationError<ValidationError<DispatchSource>, ValidatedAdvisory>
+    {
+        VerificationError::Upstream(ValidationError::Retrieval(RetrievalError::Source {
+            discovered: test_discovered(),
+            err: DispatchSourceError::Http(HttpSourceError::Fetcher(fetcher::Error::RateLimited(
+                std::time::Duration::from_secs(60),
+            ))),
+        }))
+    }
+
+    #[rstest]
+    #[case::parsing_error(parsing_error())]
+    #[case::digest_mismatch(digest_mismatch_error())]
+    #[case::file_source_error(file_source_error())]
+    #[case::rate_limited(rate_limited_error())]
+    fn returns_none_for_non_client_errors(
+        #[case] err: VerificationError<ValidationError<DispatchSource>, ValidatedAdvisory>,
+    ) {
         assert_eq!(get_client_error_status(&err), None);
     }
 }

--- a/csaf/csaf-cli/src/cmd/report/mod.rs
+++ b/csaf/csaf-cli/src/cmd/report/mod.rs
@@ -6,7 +6,7 @@ use csaf_walker::{
     discover::AsDiscovered,
     report::{DocumentKey, Duplicates, ReportRenderOption, ReportResult, render_to_html},
     retrieve::RetrievingVisitor,
-    source::DispatchSource,
+    source::{DispatchSource, DispatchSourceError, HttpSourceError},
     validation::{ValidatedAdvisory, ValidationError, ValidationVisitor},
     verification::{
         VerificationError, VerifiedAdvisory, VerifyingVisitor,
@@ -14,7 +14,7 @@ use csaf_walker::{
     },
     visitors::duplicates::DetectDuplicatesVisitor,
 };
-use reqwest::Url;
+use reqwest::{StatusCode, Url};
 use std::{
     collections::BTreeMap,
     path::PathBuf,
@@ -26,11 +26,13 @@ use std::{
 use tokio::sync::Mutex;
 use walker_common::{
     cli::{
-        CommandDefaults, client::ClientArguments, runner::RunnerArguments,
-        validation::ValidationArguments,
+        CommandDefaults, client::ClientArguments, parser::parse_allow_client_errors,
+        runner::RunnerArguments, validation::ValidationArguments,
     },
+    fetcher,
     progress::Progress,
     report::{self, Statistics},
+    retrieve::RetrievalError,
     utils::url::Urlify,
     validate::ValidationOptions,
 };
@@ -58,6 +60,14 @@ pub struct Report {
 
     #[command(flatten)]
     render: RenderOptions,
+
+    /// Shorthand for `--allow-client-errors 404`.
+    #[arg(long)]
+    allow_missing: bool,
+
+    /// Classify retrieval failures with these 4xx status codes separately in the report.
+    #[arg(long)]
+    allow_client_errors: Vec<String>,
 }
 
 impl CommandDefaults for Report {}
@@ -85,17 +95,21 @@ pub struct RenderOptions {
 impl Report {
     pub async fn run<P: Progress>(self, progress: P) -> anyhow::Result<()> {
         let options: ValidationOptions = self.validation.into();
+        let allowed_client_errors =
+            parse_allow_client_errors(self.allow_missing, self.allow_client_errors)?;
 
         let total = Arc::new(AtomicUsize::default());
         let duplicates: Arc<Mutex<Duplicates>> = Default::default();
         let errors: Arc<Mutex<BTreeMap<DocumentKey, String>>> = Default::default();
         let warnings: Arc<Mutex<BTreeMap<DocumentKey, Vec<CheckError>>>> = Default::default();
+        let ignored_errors: Arc<Mutex<BTreeMap<DocumentKey, StatusCode>>> = Default::default();
 
         {
             let total = total.clone();
             let duplicates = duplicates.clone();
             let errors = errors.clone();
             let warnings = warnings.clone();
+            let ignored_errors = ignored_errors.clone();
 
             let visitor = move |advisory: Result<
                 VerifiedAdvisory<ValidatedAdvisory, &'static str>,
@@ -105,6 +119,8 @@ impl Report {
 
                 let errors = errors.clone();
                 let warnings = warnings.clone();
+                let ignored_errors = ignored_errors.clone();
+                let allowed_client_errors = allowed_client_errors.clone();
 
                 async move {
                     let adv = match advisory {
@@ -120,6 +136,13 @@ impl Report {
                                     url: Default::default(),
                                 },
                             };
+
+                            if let Some(status) = get_client_error_status(&err) {
+                                if allowed_client_errors.contains(&status) {
+                                    ignored_errors.lock().await.insert(name, status);
+                                    return Ok::<_, anyhow::Error>(());
+                                }
+                            }
 
                             errors.lock().await.insert(name, err.to_string());
                             return Ok::<_, anyhow::Error>(());
@@ -169,6 +192,7 @@ impl Report {
         let total = (*total).load(Ordering::Acquire);
         let errors = errors.lock().await;
         let warnings = warnings.lock().await;
+        let ignored_errors = ignored_errors.lock().await;
 
         Self::render(
             &self.render,
@@ -177,6 +201,7 @@ impl Report {
                 duplicates: &*duplicates.lock().await,
                 errors: &errors,
                 warnings: &warnings,
+                ignored_errors: &ignored_errors,
             },
         )?;
 
@@ -209,4 +234,23 @@ impl Report {
 
         Ok(())
     }
+}
+
+/// Extract the HTTP client error status code from a verification error, if present.
+fn get_client_error_status(
+    err: &VerificationError<ValidationError<DispatchSource>, ValidatedAdvisory>,
+) -> Option<StatusCode> {
+    let VerificationError::Upstream(validation_err) = err else {
+        return None;
+    };
+    let ValidationError::Retrieval(retrieval_err) = validation_err else {
+        return None;
+    };
+    let RetrievalError::Source { err, .. } = retrieval_err;
+    let DispatchSourceError::Http(HttpSourceError::Fetcher(fetcher::Error::ClientError(status))) =
+        err
+    else {
+        return None;
+    };
+    Some(*status)
 }

--- a/csaf/src/report/mod.rs
+++ b/csaf/src/report/mod.rs
@@ -5,6 +5,7 @@ mod render;
 pub use render::*;
 
 use crate::discover::DiscoveredAdvisory;
+use reqwest::StatusCode;
 use std::borrow::Cow;
 use std::collections::{BTreeMap, HashSet};
 use url::Url;
@@ -16,6 +17,8 @@ pub struct ReportResult<'d> {
     pub duplicates: &'d Duplicates,
     pub errors: &'d BTreeMap<DocumentKey, String>,
     pub warnings: &'d BTreeMap<DocumentKey, Vec<Cow<'static, str>>>,
+    /// Documents that could not be retrieved due to allowed client errors (e.g. 404).
+    pub ignored_errors: &'d BTreeMap<DocumentKey, StatusCode>,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/csaf/src/report/mod.rs
+++ b/csaf/src/report/mod.rs
@@ -5,11 +5,14 @@ mod render;
 pub use render::*;
 
 use crate::discover::DiscoveredAdvisory;
+use crate::source::{DispatchSource, DispatchSourceError, HttpSourceError};
+use crate::validation::{ValidatedAdvisory, ValidationError};
+use crate::verification::VerificationError;
 use reqwest::StatusCode;
 use std::borrow::Cow;
 use std::collections::{BTreeMap, HashSet};
 use url::Url;
-use walker_common::utils::url::Urlify;
+use walker_common::{fetcher, retrieve::RetrievalError, utils::url::Urlify};
 
 #[derive(Clone, Debug)]
 pub struct ReportResult<'d> {
@@ -42,4 +45,27 @@ impl DocumentKey {
             url: advisory.possibly_relative_url(),
         }
     }
+}
+
+/// Extract the HTTP client error status code from a verification error, if present.
+///
+/// This unwraps the error chain: `VerificationError::Upstream` → `ValidationError::Retrieval`
+/// → `RetrievalError::Source` → `DispatchSourceError::Http` → `HttpSourceError::Fetcher`
+/// → `fetcher::Error::ClientError(status)`.
+pub fn get_client_error_status(
+    err: &VerificationError<ValidationError<DispatchSource>, ValidatedAdvisory>,
+) -> Option<StatusCode> {
+    let VerificationError::Upstream(validation_err) = err else {
+        return None;
+    };
+    let ValidationError::Retrieval(retrieval_err) = validation_err else {
+        return None;
+    };
+    let RetrievalError::Source { err, .. } = retrieval_err;
+    let DispatchSourceError::Http(HttpSourceError::Fetcher(fetcher::Error::ClientError(status))) =
+        err
+    else {
+        return None;
+    };
+    Some(*status)
 }

--- a/csaf/src/report/render.rs
+++ b/csaf/src/report/render.rs
@@ -38,6 +38,7 @@ pub enum Title {
     Duplicates,
     Warnings,
     Errors,
+    IgnoredErrors,
 }
 
 impl Display for Title {
@@ -46,6 +47,7 @@ impl Display for Title {
             Self::Duplicates => f.write_str("Duplicates"),
             Self::Warnings => f.write_str("Warnings"),
             Self::Errors => f.write_str("Errors"),
+            Self::IgnoredErrors => f.write_str("Ignored Errors"),
         }
     }
 }
@@ -229,6 +231,46 @@ impl HtmlReport<'_> {
         Ok(())
     }
 
+    fn render_ignored_errors(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let count = self.result.ignored_errors.len();
+
+        let data = |f: &mut Formatter<'_>| {
+            for (k, v) in self.result.ignored_errors {
+                let (url, label) = self.link_document(k);
+
+                let id = format!("ignored-error-{url}");
+                let id = html_escape::encode_quoted_attribute(&id);
+
+                writeln!(
+                    f,
+                    r##"
+            <tr>
+                <td id="{id}"><a href="{url}" target="_blank" style="white-space: nowrap;">{label}</a> <a class="link-secondary" href="#{id}">§</a></td>
+                <td><code>{v}</code></td>
+            </tr>
+            "##,
+                    url = html_escape::encode_quoted_attribute(&url),
+                    label = html_escape::encode_text(&label),
+                    v = html_escape::encode_text(&v.to_string()),
+                )?;
+            }
+            Ok(())
+        };
+        if count > 0 {
+            Self::render_table(
+                f,
+                [count],
+                Title::IgnoredErrors,
+                &format!(
+                    "{count} file(s) with ignored retrieval errors",
+                    count = Formatted(count),
+                ),
+                data,
+            )?;
+        }
+        Ok(())
+    }
+
     fn gen_link(&self, key: &DocumentKey) -> Option<(String, String)> {
         let label = key.url.clone();
 
@@ -262,7 +304,7 @@ impl HtmlReport<'_> {
             let (class, text) = if count > 0 {
                 (
                     match title {
-                        Title::Warnings => "text-bg-warning",
+                        Title::Warnings | Title::IgnoredErrors => "text-bg-warning",
                         _ => "text-bg-danger",
                     },
                     Formatted(count).to_string(),
@@ -299,6 +341,7 @@ impl Display for HtmlReport<'_> {
         self.render_total(f)?;
         self.render_duplicates(f)?;
         self.render_errors(f)?;
+        self.render_ignored_errors(f)?;
         self.render_warnings(f)?;
         Ok(())
     }
@@ -317,6 +360,7 @@ mod test {
             duplicates: &Default::default(),
             errors: &Default::default(),
             warnings: &Default::default(),
+            ignored_errors: &Default::default(),
         };
         let _output = PathBuf::default();
         let base_url = Some(Url::parse("file:///foo/bar/").expect("example value must parse"));

--- a/csaf/tests/report-ignored-errors.rs
+++ b/csaf/tests/report-ignored-errors.rs
@@ -1,0 +1,305 @@
+use csaf_walker::{
+    discover::AsDiscovered,
+    report::{DocumentKey, Duplicates, get_client_error_status},
+    retrieve::RetrievingVisitor,
+    source::{DispatchSource, HttpOptions, HttpSource},
+    validation::{ValidatedAdvisory, ValidationError, ValidationVisitor},
+    verification::{
+        VerificationError, VerifiedAdvisory, VerifyingVisitor,
+        check::{CheckError, init_verifying_visitor},
+    },
+    visitors::duplicates::DetectDuplicatesVisitor,
+    walker::Walker,
+};
+use reqwest::{StatusCode, Url};
+use std::{
+    collections::{BTreeMap, HashSet},
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
+use tokio::net::TcpListener;
+use tokio::sync::Mutex;
+use walker_common::{
+    fetcher::{Fetcher, FetcherOptions},
+    utils::url::Urlify,
+    validate::ValidationOptions,
+};
+
+const PROVIDER_METADATA_TEMPLATE: &str = r#"{
+    "canonical_url": "CANONICAL_URL",
+    "distributions": [{
+        "directory_url": "DIST_URL"
+    }],
+    "last_updated": "2024-01-01T00:00:00Z",
+    "list_on_CSAF_aggregators": false,
+    "metadata_version": "2.0",
+    "mirror_on_CSAF_aggregators": false,
+    "public_openpgp_keys": [],
+    "publisher": {
+        "category": "vendor",
+        "contact_details": "test@example.com",
+        "name": "Test Corp",
+        "namespace": "https://example.com"
+    },
+    "role": "csaf_provider"
+}"#;
+
+const GOOD_ADVISORY: &str = r#"{
+    "document": {
+        "category": "csaf_base",
+        "csaf_version": "2.0",
+        "title": "Test Advisory",
+        "publisher": {
+            "category": "vendor",
+            "name": "Test Corp",
+            "namespace": "https://example.com"
+        },
+        "tracking": {
+            "id": "TEST-2024-001",
+            "status": "final",
+            "version": "1",
+            "revision_history": [{"date":"2024-01-01T00:00:00Z","number":"1","summary":"Initial"}],
+            "initial_release_date": "2024-01-01T00:00:00Z",
+            "current_release_date": "2024-01-01T00:00:00Z"
+        }
+    }
+}"#;
+
+/// Start a mock HTTP server that:
+/// - Serves provider-metadata.json at the root
+/// - Serves changes.csv listing two advisories
+/// - Returns 200 for good.json and 404 for missing.json
+async fn start_csaf_mock_server() -> String {
+    use hyper::service::service_fn;
+    use hyper_util::rt::TokioIo;
+    use std::convert::Infallible;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let base_url = format!("http://{addr}");
+
+    let base_for_handler = base_url.clone();
+    tokio::spawn(async move {
+        loop {
+            let (stream, _) = listener.accept().await.unwrap();
+            let io = TokioIo::new(stream);
+            let base = base_for_handler.clone();
+
+            tokio::spawn(async move {
+                let service = service_fn(move |req: hyper::Request<hyper::body::Incoming>| {
+                    let base = base.clone();
+                    async move {
+                        let path = req.uri().path().to_string();
+                        let response = match path.as_str() {
+                            "/provider-metadata.json" => {
+                                let body = PROVIDER_METADATA_TEMPLATE
+                                    .replace(
+                                        "CANONICAL_URL",
+                                        &format!("{base}/provider-metadata.json"),
+                                    )
+                                    .replace("DIST_URL", &format!("{base}/advisories/"));
+                                hyper::Response::builder()
+                                    .status(StatusCode::OK)
+                                    .header("Content-Type", "application/json")
+                                    .body(body)
+                                    .unwrap()
+                            }
+                            "/advisories/changes.csv" => hyper::Response::builder()
+                                .status(StatusCode::OK)
+                                .body(
+                                    "good.json,2024-01-01T00:00:00Z\nmissing.json,2024-01-01T00:00:00Z\n"
+                                        .to_string(),
+                                )
+                                .unwrap(),
+                            "/advisories/good.json" => hyper::Response::builder()
+                                .status(StatusCode::OK)
+                                .header("Content-Type", "application/json")
+                                .body(GOOD_ADVISORY.to_string())
+                                .unwrap(),
+                            // 404 for the advisory itself
+                            "/advisories/missing.json" => hyper::Response::builder()
+                                .status(StatusCode::NOT_FOUND)
+                                .body("Not found".to_string())
+                                .unwrap(),
+                            // .asc and .sha256/.sha512 files return 404 (treated as optional)
+                            _ => hyper::Response::builder()
+                                .status(StatusCode::NOT_FOUND)
+                                .body("Not found".to_string())
+                                .unwrap(),
+                        };
+                        Ok::<_, Infallible>(response)
+                    }
+                });
+
+                if let Err(err) = hyper::server::conn::http1::Builder::new()
+                    .serve_connection(io, service)
+                    .await
+                {
+                    eprintln!("Error serving connection: {err:?}");
+                }
+            });
+        }
+    });
+
+    base_url
+}
+
+/// Run the report visitor pipeline against a source with the given allowed client errors,
+/// returning (errors, ignored_errors, total).
+async fn run_report(
+    source: DispatchSource,
+    allowed_client_errors: HashSet<StatusCode>,
+) -> (
+    BTreeMap<DocumentKey, String>,
+    BTreeMap<DocumentKey, StatusCode>,
+    usize,
+) {
+    let total = Arc::new(AtomicUsize::default());
+    let duplicates: Arc<Mutex<Duplicates>> = Default::default();
+    let errors: Arc<Mutex<BTreeMap<DocumentKey, String>>> = Default::default();
+    let warnings: Arc<Mutex<BTreeMap<DocumentKey, Vec<CheckError>>>> = Default::default();
+    let ignored_errors: Arc<Mutex<BTreeMap<DocumentKey, StatusCode>>> = Default::default();
+
+    {
+        let total = total.clone();
+        let errors = errors.clone();
+        let warnings = warnings.clone();
+        let ignored_errors = ignored_errors.clone();
+        let duplicates = duplicates.clone();
+
+        let visitor = move |advisory: Result<
+            VerifiedAdvisory<ValidatedAdvisory, &'static str>,
+            VerificationError<ValidationError<DispatchSource>, ValidatedAdvisory>,
+        >| {
+            (*total).fetch_add(1, Ordering::Release);
+
+            let errors = errors.clone();
+            let warnings = warnings.clone();
+            let ignored_errors = ignored_errors.clone();
+            let allowed_client_errors = allowed_client_errors.clone();
+
+            async move {
+                let adv = match advisory {
+                    Ok(adv) => adv,
+                    Err(err) => {
+                        let name = match err.as_discovered().relative_base_and_url() {
+                            Some((base, relative)) => DocumentKey {
+                                distribution_url: base.clone(),
+                                url: relative,
+                            },
+                            None => DocumentKey {
+                                distribution_url: err.url().clone(),
+                                url: Default::default(),
+                            },
+                        };
+
+                        if let Some(status) = get_client_error_status(&err)
+                            && allowed_client_errors.contains(&status)
+                        {
+                            ignored_errors.lock().await.insert(name, status);
+                            return Ok::<_, anyhow::Error>(());
+                        }
+
+                        errors.lock().await.insert(name, err.to_string());
+                        return Ok::<_, anyhow::Error>(());
+                    }
+                };
+
+                if !adv.failures.is_empty() {
+                    let name = DocumentKey::for_document(&adv);
+                    warnings
+                        .lock()
+                        .await
+                        .entry(name)
+                        .or_default()
+                        .extend(adv.failures.into_values().flatten());
+                }
+
+                Ok::<_, anyhow::Error>(())
+            }
+        };
+
+        let visitor = VerifyingVisitor::with_checks(visitor, init_verifying_visitor());
+        let visitor = ValidationVisitor::new(visitor).with_options(ValidationOptions::default());
+        let visitor = RetrievingVisitor::new(source.clone(), visitor);
+        let visitor = DetectDuplicatesVisitor {
+            duplicates,
+            visitor,
+        };
+
+        Walker::new(source)
+            .with_progress(())
+            .walk(visitor)
+            .await
+            .expect("walk should succeed");
+    }
+
+    let total = total.load(Ordering::Acquire);
+    let errors = errors.lock().await.clone();
+    let ignored_errors = ignored_errors.lock().await.clone();
+
+    (errors, ignored_errors, total)
+}
+
+#[tokio::test]
+async fn report_with_allow_missing_classifies_404_as_ignored() {
+    let base_url = start_csaf_mock_server().await;
+
+    let metadata_url = Url::parse(&format!("{base_url}/provider-metadata.json")).unwrap();
+    let fetcher = Fetcher::new(FetcherOptions::default()).await.unwrap();
+    let source: DispatchSource =
+        HttpSource::new(metadata_url, fetcher, HttpOptions::default()).into();
+
+    let mut allowed = HashSet::new();
+    allowed.insert(StatusCode::NOT_FOUND);
+
+    let (errors, ignored_errors, total) = run_report(source, allowed).await;
+
+    assert_eq!(total, 2, "should process both advisories");
+    assert!(
+        errors.is_empty(),
+        "no hard errors expected, got: {errors:?}"
+    );
+    assert_eq!(
+        ignored_errors.len(),
+        1,
+        "one ignored error expected for missing.json"
+    );
+
+    let (key, status) = ignored_errors.iter().next().unwrap();
+    assert_eq!(*status, StatusCode::NOT_FOUND);
+    assert!(
+        key.url.contains("missing.json"),
+        "ignored error should be for missing.json, got: {}",
+        key.url
+    );
+}
+
+#[tokio::test]
+async fn report_without_allow_missing_treats_404_as_error() {
+    let base_url = start_csaf_mock_server().await;
+
+    let metadata_url = Url::parse(&format!("{base_url}/provider-metadata.json")).unwrap();
+    let fetcher = Fetcher::new(FetcherOptions::default()).await.unwrap();
+    let source: DispatchSource =
+        HttpSource::new(metadata_url, fetcher, HttpOptions::default()).into();
+
+    // No allowed client errors
+    let (errors, ignored_errors, total) = run_report(source, HashSet::new()).await;
+
+    assert_eq!(total, 2, "should process both advisories");
+    assert!(
+        ignored_errors.is_empty(),
+        "no ignored errors expected without allow-missing"
+    );
+    assert_eq!(errors.len(), 1, "one hard error expected for missing.json");
+
+    let (key, _msg) = errors.iter().next().unwrap();
+    assert!(
+        key.url.contains("missing.json"),
+        "error should be for missing.json, got: {}",
+        key.url
+    );
+}


### PR DESCRIPTION
relates to #69 


## Summary by Sourcery

Classify certain HTTP client retrieval errors as ignorable in CSAF reports and surface them separately in the HTML output.

New Features:
- Add CLI options to allow treating specified HTTP 4xx retrieval status codes, including a shorthand for 404, as ignorable in report generation.
- Include a separate "Ignored Errors" section in the HTML report summarizing advisories skipped due to allowed client errors.

Enhancements:
- Extract helper logic to detect HTTP client-error status codes from verification errors and reuse it in reporting.

Build:
- Add rstest as a dev-dependency for CLI crate tests.

Tests:
- Add unit tests for extracting client error status codes from verification errors and for the report behavior with and without allowed missing (404) advisories using a mock HTTP server.