### PR TITLE
fix: make contact_details optional and convert category and metadata_version to enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.91.0"
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.dependencies]
 anyhow = "1"
@@ -75,10 +75,10 @@ walkdir = "2.4"
 
 # internal dependencies
 
-csaf-walker = { version = "0.16.0", path = "csaf", default-features = false }
-sbom-walker = { version = "0.16.0", path = "sbom", default-features = false }
-walker-common = { version = "0.16.0", path = "common" }
-walker-extras = { version = "0.16.0", path = "extras" }
+csaf-walker = { version = "0.17.0", path = "csaf", default-features = false }
+sbom-walker = { version = "0.17.0", path = "sbom", default-features = false }
+walker-common = { version = "0.17.0", path = "common" }
+walker-extras = { version = "0.17.0", path = "extras" }
 
 [workspace.metadata.release]
 tag = false

--- a/csaf/src/model/metadata.rs
+++ b/csaf/src/model/metadata.rs
@@ -64,7 +64,7 @@ pub struct Publisher {
     pub namespace: String,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PublisherCategory {
     Coordinator,
@@ -73,6 +73,8 @@ pub enum PublisherCategory {
     Translator,
     User,
     Vendor,
+    #[serde(untagged)]
+    Unknown(String),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Deserialize, serde::Serialize)]

--- a/csaf/src/model/metadata.rs
+++ b/csaf/src/model/metadata.rs
@@ -75,10 +75,12 @@ pub enum PublisherCategory {
     Vendor,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Deserialize, serde::Serialize)]
 pub enum MetadataVersion {
     #[serde(rename = "2.0")]
     V2_0,
+    #[serde(untagged)]
+    Unknown(String),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]

--- a/csaf/src/model/metadata.rs
+++ b/csaf/src/model/metadata.rs
@@ -55,12 +55,30 @@ impl<'a> From<&'a Key> for walker_common::validate::source::Key<'a> {
 
 #[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct Publisher {
-    pub category: String,
-    pub contact_details: String,
+    pub category: PublisherCategory,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub contact_details: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub issuing_authority: Option<String>,
     pub name: String,
     pub namespace: String,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PublisherCategory {
+    Coordinator,
+    Discoverer,
+    Other,
+    Translator,
+    User,
+    Vendor,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, serde::Deserialize, serde::Serialize)]
+pub enum MetadataVersion {
+    #[serde(rename = "2.0")]
+    V2_0,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
@@ -76,7 +94,7 @@ pub struct ProviderMetadata {
     #[serde(default)]
     pub list_on_csaf_aggregators: bool,
 
-    pub metadata_version: String,
+    pub metadata_version: MetadataVersion,
 
     #[serde(rename = "mirror_on_CSAF_aggregators")]
     #[serde(default)]

--- a/csaf/tests/store-visitor.rs
+++ b/csaf/tests/store-visitor.rs
@@ -1,7 +1,9 @@
 use bytes::Bytes;
 use csaf_walker::{
     discover::{DiscoveredAdvisory, DistributionContext},
-    model::metadata::{Distribution, ProviderMetadata, Publisher, Role},
+    model::metadata::{
+        Distribution, MetadataVersion, ProviderMetadata, Publisher, PublisherCategory, Role,
+    },
     retrieve::{RetrievedAdvisory, RetrievedVisitor},
     source::{FileSource, HttpSource, HttpSourceError},
     visitors::store::StoreVisitor,
@@ -26,12 +28,12 @@ fn create_test_metadata() -> ProviderMetadata {
         }],
         last_updated: chrono::Utc::now(),
         list_on_csaf_aggregators: false,
-        metadata_version: "2.0".to_string(),
+        metadata_version: MetadataVersion::V2_0,
         mirror_on_csaf_aggregators: false,
         public_openpgp_keys: vec![],
         publisher: Publisher {
-            category: "vendor".to_string(),
-            contact_details: "security@example.com".to_string(),
+            category: PublisherCategory::Vendor,
+            contact_details: Some("security@example.com".to_string()),
             issuing_authority: None,
             name: "Example Corp".to_string(),
             namespace: "https://example.com".to_string(),


### PR DESCRIPTION
- make contact_details optional according to official schema
- convert category and metadata_version to an enum according to official schema

resolves #78

## Summary by Sourcery

Align CSAF metadata model with the official schema by making publisher contact details optional and constraining category and metadata version to enums.

New Features:
- Introduce typed enums for publisher category and metadata version in the CSAF metadata model.

Bug Fixes:
- Make publisher contact details optional to comply with the official CSAF schema.

Tests:
- Update CSAF store-visitor test metadata to use the new enums and optional contact details field.