### PR TITLE
feat: make sequoia-openpgp optional in csaf-walker

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -15,8 +15,6 @@ pub mod since;
 pub mod source;
 pub mod store;
 pub mod utils;
-
-#[cfg(feature = "openpgp")]
 pub mod validate;
 
 #[cfg(feature = "clap")]

--- a/common/src/validate/mod.rs
+++ b/common/src/validate/mod.rs
@@ -3,7 +3,10 @@ mod error;
 pub use error::*;
 
 pub mod digest;
+
+#[cfg(feature = "openpgp")]
 pub mod openpgp;
+#[cfg(feature = "openpgp")]
 pub mod source;
 
 use std::time::SystemTime;

--- a/csaf/Cargo.toml
+++ b/csaf/Cargo.toml
@@ -31,7 +31,6 @@ parking_lot = { workspace = true }
 percent-encoding = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 sectxtlib = { workspace = true }
-sequoia-openpgp = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
@@ -43,9 +42,10 @@ walkdir = { workspace = true }
 
 # optional
 csaf = { workspace = true, optional = true }
+sequoia-openpgp = { workspace = true, optional = true }
 
 # internal
-walker-common = { workspace = true, features = ["openpgp"] }
+walker-common = { workspace = true }
 
 [dev-dependencies]
 env_logger = { workspace = true }
@@ -53,25 +53,27 @@ hyper = { version = "1", features = ["server", "http1"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net"] }
-walker-common = { workspace = true, features = ["openpgp", "lzma"] }
+walker-common = { workspace = true, features = ["lzma"] }
 
 [features]
-default = ["crypto-nettle", "csaf"]
-crypto-cng = ["sequoia-openpgp/crypto-cng"]
-crypto-nettle = ["sequoia-openpgp/crypto-nettle"]
-crypto-openssl = ["sequoia-openpgp/crypto-openssl"]
-crypto-botan = ["sequoia-openpgp/crypto-botan"]
-crypto-rust = ["sequoia-openpgp/crypto-rust"]
+default = ["openpgp", "crypto-nettle", "csaf"]
+openpgp = ["sequoia-openpgp", "walker-common/openpgp"]
+crypto-cng = ["openpgp", "sequoia-openpgp/crypto-cng"]
+crypto-nettle = ["openpgp", "sequoia-openpgp/crypto-nettle"]
+crypto-openssl = ["openpgp", "sequoia-openpgp/crypto-openssl"]
+crypto-botan = ["openpgp", "sequoia-openpgp/crypto-botan"]
+crypto-rust = ["openpgp", "sequoia-openpgp/crypto-rust"]
 
 # enable for semver checks (in addition to default)
 _semver = []
 
 [package.metadata.cargo-all-features]
 always_include_features = [
-    "crypto-nettle",
+    "sequoia-openpgp/crypto-nettle",
 ]
 denylist = [
     "crypto-cng",
+    "crypto-nettle",
     "crypto-openssl",
     "crypto-botan",
     "crypto-rust",

--- a/csaf/src/model/metadata.rs
+++ b/csaf/src/model/metadata.rs
@@ -44,6 +44,7 @@ pub struct Key {
     pub url: Url,
 }
 
+#[cfg(feature = "openpgp")]
 impl<'a> From<&'a Key> for walker_common::validate::source::Key<'a> {
     fn from(value: &'a Key) -> Self {
         walker_common::validate::source::Key {

--- a/csaf/src/retrieve.rs
+++ b/csaf/src/retrieve.rs
@@ -14,7 +14,12 @@ use std::{
 use url::Url;
 use walker_common::{
     retrieve::{RetrievalError, RetrievalMetadata, RetrievedDigest, RetrievedDocument},
-    utils::{openpgp::PublicKey, url::Urlify},
+    utils::url::Urlify,
+};
+
+#[cfg(feature = "openpgp")]
+use walker_common::{
+    utils::openpgp::PublicKey,
     validate::source::{KeySource, KeySourceError},
 };
 
@@ -85,6 +90,7 @@ impl RetrievedDocument for RetrievedAdvisory {
 
 pub struct RetrievalContext<'c> {
     pub discovered: &'c DiscoveredContext<'c>,
+    #[cfg(feature = "openpgp")]
     pub keys: &'c Vec<PublicKey>,
 }
 
@@ -138,7 +144,7 @@ where
     }
 }
 
-pub struct RetrievingVisitor<V: RetrievedVisitor<S>, S: Source + KeySource> {
+pub struct RetrievingVisitor<V: RetrievedVisitor<S>, S: Source> {
     visitor: V,
     source: S,
 }
@@ -146,13 +152,33 @@ pub struct RetrievingVisitor<V: RetrievedVisitor<S>, S: Source + KeySource> {
 impl<V, S> RetrievingVisitor<V, S>
 where
     V: RetrievedVisitor<S>,
-    S: Source + KeySource,
+    S: Source,
 {
     pub fn new(source: S, visitor: V) -> Self {
         Self { visitor, source }
     }
+
+    /// Load a single advisory and hand the outcome over to the wrapped visitor.
+    async fn load_and_visit(
+        &self,
+        context: &V::Context,
+        discovered: DiscoveredAdvisory,
+    ) -> Result<(), V::Error> {
+        let advisory = self
+            .source
+            .load_advisory(discovered.clone())
+            .await
+            .map_err(|err| RetrievalError::Source { err, discovered });
+
+        self.visitor.visit_advisory(context, advisory).await
+    }
 }
 
+/// An error from the [`RetrievingVisitor`].
+///
+/// With the `openpgp` feature disabled, this type has no `KSE` (key source
+/// error) parameter and no `KeySource` variant.
+#[cfg(feature = "openpgp")]
 #[derive(Debug, thiserror::Error)]
 pub enum Error<VE, SE, KSE>
 where
@@ -168,6 +194,24 @@ where
     Visitor(VE),
 }
 
+/// An error from the [`RetrievingVisitor`].
+///
+/// With the `openpgp` feature enabled, this type has an additional `KSE` (key
+/// source error) parameter and a `KeySource` variant.
+#[cfg(not(feature = "openpgp"))]
+#[derive(Debug, thiserror::Error)]
+pub enum Error<VE, SE>
+where
+    VE: std::fmt::Display + Debug,
+    SE: std::fmt::Display + Debug,
+{
+    #[error("Source error: {0}")]
+    Source(SE),
+    #[error(transparent)]
+    Visitor(VE),
+}
+
+#[cfg(feature = "openpgp")]
 impl<V, S> DiscoveredVisitor for RetrievingVisitor<V, S>
 where
     V: RetrievedVisitor<S>,
@@ -224,17 +268,40 @@ where
         context: &Self::Context,
         discovered: DiscoveredAdvisory,
     ) -> Result<(), Self::Error> {
-        let advisory = self
-            .source
-            .load_advisory(discovered.clone())
+        self.load_and_visit(context, discovered)
             .await
-            .map_err(|err| RetrievalError::Source { err, discovered });
+            .map_err(Error::Visitor)
+    }
+}
 
+#[cfg(not(feature = "openpgp"))]
+impl<V, S> DiscoveredVisitor for RetrievingVisitor<V, S>
+where
+    V: RetrievedVisitor<S>,
+    S: Source,
+{
+    type Error = Error<V::Error, <S as walker_common::source::Source>::Error>;
+    type Context = V::Context;
+
+    async fn visit_context(
+        &self,
+        context: &DiscoveredContext<'_>,
+    ) -> Result<Self::Context, Self::Error> {
         self.visitor
-            .visit_advisory(context, advisory)
+            .visit_context(&RetrievalContext {
+                discovered: context,
+            })
             .await
-            .map_err(Error::Visitor)?;
+            .map_err(Error::Visitor)
+    }
 
-        Ok(())
+    async fn visit_advisory(
+        &self,
+        context: &Self::Context,
+        discovered: DiscoveredAdvisory,
+    ) -> Result<(), Self::Error> {
+        self.load_and_visit(context, discovered)
+            .await
+            .map_err(Error::Visitor)
     }
 }

--- a/csaf/src/source/dispatch.rs
+++ b/csaf/src/source/dispatch.rs
@@ -3,6 +3,7 @@ use crate::discover::{DiscoveredAdvisory, DistributionContext};
 use crate::model::metadata::ProviderMetadata;
 use crate::retrieve::RetrievedAdvisory;
 use crate::source::{FileSource, HttpSource};
+#[cfg(feature = "openpgp")]
 use walker_common::{
     utils::openpgp::PublicKey,
     validate::source::{Key, KeySource, KeySourceError, MapSourceError},
@@ -93,6 +94,7 @@ impl Source for DispatchSource {
     }
 }
 
+#[cfg(feature = "openpgp")]
 impl KeySource for DispatchSource {
     type Error = anyhow::Error;
 

--- a/csaf/src/source/file.rs
+++ b/csaf/src/source/file.rs
@@ -20,9 +20,11 @@ use time::OffsetDateTime;
 use tokio::sync::mpsc;
 use url::Url;
 use walkdir::WalkDir;
+use walker_common::{retrieve::RetrievalMetadata, source::file::read_sig_and_digests};
+
+#[cfg(feature = "openpgp")]
 use walker_common::{
-    retrieve::RetrievalMetadata,
-    source::file::{read_sig_and_digests, to_path},
+    source::file::to_path,
     utils::{self, openpgp::PublicKey},
     validate::source::{Key, KeySource, KeySourceError},
 };
@@ -271,6 +273,7 @@ impl Source for FileSource {
     }
 }
 
+#[cfg(feature = "openpgp")]
 impl KeySource for FileSource {
     type Error = anyhow::Error;
 

--- a/csaf/src/source/http.rs
+++ b/csaf/src/source/http.rs
@@ -19,6 +19,10 @@ use walker_common::{
     changes::{self, ChangeEntry, ChangeSource},
     fetcher::{self, DataProcessor, Fetcher},
     retrieve::{RetrievalMetadata, RetrievedDigest, RetrievingDigest},
+};
+
+#[cfg(feature = "openpgp")]
+use walker_common::{
     utils::openpgp::PublicKey,
     validate::source::{Key, KeySource, KeySourceError},
 };
@@ -320,6 +324,7 @@ impl DataProcessor for FetchingRetrievedAdvisory {
     }
 }
 
+#[cfg(feature = "openpgp")]
 impl KeySource for HttpSource {
     type Error = fetcher::Error;
 

--- a/csaf/src/validation/mod.rs
+++ b/csaf/src/validation/mod.rs
@@ -14,9 +14,12 @@ use std::{
 use url::Url;
 use walker_common::{
     retrieve::RetrievalError,
-    utils::{openpgp::PublicKey, url::Urlify},
-    validate::{ValidationOptions, digest::validate_digest, openpgp},
+    utils::url::Urlify,
+    validate::{ValidationOptions, digest::validate_digest},
 };
+
+#[cfg(feature = "openpgp")]
+use walker_common::{utils::openpgp::PublicKey, validate::openpgp};
 
 /// A validated CSAF document
 ///
@@ -183,6 +186,8 @@ where
     S: Source,
 {
     visitor: V,
+    // without the openpgp feature, this is only set, never read
+    #[cfg_attr(not(feature = "openpgp"), allow(unused))]
     options: ValidationOptions,
     _marker: PhantomData<S>,
 }
@@ -228,6 +233,8 @@ where
     /// Perform the actual validation.
     ///
     /// Returning either a processing error, or a result which will be forwarded to the visitor.
+    // without the openpgp feature, `context` (holding the keys) is unused
+    #[cfg_attr(not(feature = "openpgp"), allow(unused_variables))]
     async fn validate(
         &self,
         context: &InnerValidationContext<V::Context>,
@@ -252,8 +259,9 @@ where
             ));
         }
 
+        #[cfg(feature = "openpgp")]
         if let Some(signature) = &retrieved.signature {
-            match openpgp::validate_signature(
+            return match openpgp::validate_signature(
                 &self.options,
                 &context.keys,
                 signature,
@@ -263,15 +271,16 @@ where
                 Err(error) => Err(ValidationProcessError::Proceed(
                     ValidationError::Signature { error, retrieved },
                 )),
-            }
-        } else {
-            Ok(ValidatedAdvisory { retrieved })
+            };
         }
+
+        Ok(ValidatedAdvisory { retrieved })
     }
 }
 
 pub struct InnerValidationContext<VC> {
     context: VC,
+    #[cfg(feature = "openpgp")]
     keys: Vec<PublicKey>,
 }
 
@@ -287,6 +296,7 @@ where
         &self,
         context: &RetrievalContext<'_>,
     ) -> Result<Self::Context, Self::Error> {
+        #[cfg(feature = "openpgp")]
         let keys = context.keys.clone();
 
         let context = self
@@ -295,7 +305,11 @@ where
             .await
             .map_err(Error::Visitor)?;
 
-        Ok(Self::Context { context, keys })
+        Ok(Self::Context {
+            context,
+            #[cfg(feature = "openpgp")]
+            keys,
+        })
     }
 
     async fn visit_advisory(

--- a/csaf/src/visitors/store.rs
+++ b/csaf/src/visitors/store.rs
@@ -6,22 +6,20 @@ use crate::{
     validation::{ValidatedAdvisory, ValidatedVisitor, ValidationContext, ValidationError},
 };
 use anyhow::Context;
-use sequoia_openpgp::{Cert, armor::Kind, serialize::SerializeInto};
-use std::{
-    any::Any,
-    collections::HashSet,
-    fmt::Debug,
-    io::{ErrorKind, Write},
-    path::{Path, PathBuf},
-    rc::Rc,
-};
+use std::{any::Any, collections::HashSet, fmt::Debug, io::ErrorKind, path::PathBuf, rc::Rc};
 use tokio::fs;
 use walker_common::{
     fetcher,
     retrieve::RetrievalError,
     store::{Document, ErrorData, StoreError, store_document, store_errors},
-    utils::openpgp::PublicKey,
 };
+
+#[cfg(feature = "openpgp")]
+use sequoia_openpgp::{Cert, armor::Kind, serialize::SerializeInto};
+#[cfg(feature = "openpgp")]
+use std::{io::Write, path::Path};
+#[cfg(feature = "openpgp")]
+use walker_common::utils::openpgp::PublicKey;
 
 pub const DIR_METADATA: &str = "metadata";
 
@@ -110,6 +108,7 @@ where
     ) -> Result<Self::Context, Self::Error> {
         self.store_provider_metadata(context.metadata).await?;
         self.prepare_distributions(context.metadata).await?;
+        #[cfg(feature = "openpgp")]
         self.store_keys(context.keys).await?;
 
         Ok(Rc::new(context.metadata.clone()))
@@ -150,6 +149,7 @@ impl<S: Source> ValidatedVisitor<S> for StoreVisitor {
     ) -> Result<Self::Context, Self::Error> {
         self.store_provider_metadata(context.metadata).await?;
         self.prepare_distributions(context.metadata).await?;
+        #[cfg(feature = "openpgp")]
         self.store_keys(context.retrieval.keys).await?;
         Ok(())
     }
@@ -227,6 +227,7 @@ impl StoreVisitor {
         Ok(())
     }
 
+    #[cfg(feature = "openpgp")]
     async fn store_keys(&self, keys: &[PublicKey]) -> Result<(), StoreError> {
         let metadata = self.base.join(DIR_METADATA).join("keys");
         std::fs::create_dir(&metadata)
@@ -251,6 +252,7 @@ impl StoreVisitor {
         Ok(())
     }
 
+    #[cfg(feature = "openpgp")]
     async fn store_cert(&self, cert: &Cert, path: &Path) -> Result<(), StoreError> {
         let name = path.join(format!("{}.txt", cert.fingerprint().to_hex()));
 
@@ -263,6 +265,7 @@ impl StoreVisitor {
         Ok(())
     }
 
+    #[cfg(feature = "openpgp")]
     fn serialize_key(cert: &Cert) -> Result<Vec<u8>, anyhow::Error> {
         let mut writer = sequoia_openpgp::armor::Writer::new(Vec::new(), Kind::PublicKey)?;
         writer.write_all(&cert.to_vec()?)?;


### PR DESCRIPTION
# Motivation

`sequoia-openpgp` is LGPL-2.0-or-later, while csaf-walker itself is Apache-2.0. For consumers that link statically and have a permissive-only license policy, that currently makes `csaf-walker` unusable even when they don't need signature verification. `walker-common` already ships the solution for this — its `sequoia-openpgp` dependency is optional behind an `openpgp` feature — but `csaf-walker` depends on sequoia unconditionally and force-enables `walker-common/openpgp`.

This PR extends the existing `walker-common` pattern to the `csaf-walker` crate.

# What this does

**`walker-common`** (first commit): the whole `validate` module was gated behind `openpgp`, but only `validate::openpgp` and `validate::source` actually use sequoia types. The gate is narrowed to those two submodules, so `validate::digest`, `ValidationError`, and `ValidationOptions` are now available without the feature. Purely additive — nothing changes for builds with `openpgp` enabled.

**`csaf-walker`** (second commit):

- `sequoia-openpgp` becomes `optional = true`, gated behind a new `openpgp` feature which also forwards to `walker-common/openpgp`.
- `openpgp` is **on by default**, so plain `cargo add csaf-walker` behaves exactly as before.
- Every `crypto-*` backend feature implies `openpgp`. Existing users building with `--no-default-features --features crypto-openssl,csaf` keep signature verification — selecting a crypto backend never silently turns verification off.
- With the feature disabled, the following are compiled out: the `KeySource` impls on `HttpSource`/`FileSource`/`DispatchSource`, public key loading in `RetrievingVisitor`, signature verification in `ValidationVisitor` (digest validation is kept), key storage in `StoreVisitor`, and `RetrievalContext::keys`.
- The dev-dependency on `walker-common` no longer forces `openpgp`, so the test suite genuinely runs in both configurations.
- `cargo-all-features` metadata switches to the same shape `walker-common` already uses (`always_include_features = ["sequoia-openpgp/crypto-nettle"]`, backends denylisted), so the powerset now covers the openpgp-off combinations while still always giving sequoia a crypto backend.

One API note: `retrieve::Error` loses its third type parameter (`KSE`) and its `KeySource` variant when the feature is off, and the public `keys` fields disappear. That is only observable for opt-out builds; with default features the API is unchanged (same shape as 0.17.0). This mirrors how `walker-common` already handles `openpgp`/`s3` gating.

# Verification

All of the following pass locally (macOS, Rust 1.96; `crypto-openssl` used because nettle isn't available here — CI covers `crypto-nettle`):

- `cargo test -p csaf-walker --no-default-features --features csaf` (20 tests + doctests, no sequoia in the tree at all)
- `cargo test -p csaf-walker --no-default-features --features csaf,crypto-openssl` (same 20 tests + doctests)
- `cargo clippy --all-targets` for both configurations, no findings
- `cargo check -p csaf-walker --no-default-features --features sequoia-openpgp/crypto-openssl` (the sequoia-on/openpgp-off combination cargo-all-features will produce)
- `cargo check` for `csaf-cli`, `sbom-walker`, `sbom-cli`, and `walker-extras` against the changed crates
- `cargo fmt --check`

# Follow-ups (happy to do either in this PR or separately)

- `sbom-walker` has the identical pattern (unconditional sequoia + forced `walker-common/openpgp`) and could get the same treatment. I kept this PR scoped to the CSAF side to keep the diff reviewable — say the word and I'll extend it or send a follow-up.
- Pre-existing, but now reachable: `walker-common`'s CLI `ValidationArguments` (`--policy-date`, `--v3-signatures`) is gated only on `clap`, so a `clap`-without-`openpgp` build would accept those flags as silent no-ops. Worth a small follow-up if you care about that combination.

## Summary by Sourcery

Make OpenPGP support in csaf-walker optional while preserving existing behavior by default, aligning feature gating with walker-common and allowing builds without sequoia-openpgp.

New Features:
- Introduce an openpgp feature in csaf-walker that gates sequoia-openpgp and forwards to walker-common/openpgp, enabled by default.
- Allow building and using csaf-walker without OpenPGP-related types, key handling, and signature verification when the openpgp feature is disabled.

Enhancements:
- Refine walker-common’s validate module gating so digest validation and core validation types are available without the openpgp feature.
- Adjust csaf-walker’s retrieval, validation, source, and store visitors to compile out key handling and signature verification when OpenPGP is disabled, keeping digest validation intact.
- Update feature implications so all crypto-* backend features automatically enable OpenPGP support instead of silently disabling signature verification.
- Align cargo-all-features metadata to always give sequoia-openpgp a crypto backend while exercising openpgp-off combinations.
- Relax dev-dependency feature requirements so tests run both with and without OpenPGP enabled.

Build:
- Make sequoia-openpgp an optional dependency of csaf-walker and remove unconditional walker-common/openpgp from its dependency configuration.
- Update csaf-walker feature definitions and cargo-all-features metadata to reflect the new openpgp gating and crypto backend denylist.